### PR TITLE
Test for Map behavior that breaks Playwright

### DIFF
--- a/js/src/tests/non262/taint/maps.js
+++ b/js/src/tests/non262/taint/maps.js
@@ -1,0 +1,18 @@
+function mapTaintTest() {
+
+  let map = new Map(); 
+  let tainted = taint(42);
+  let untainted = 42;
+  let value = "foo";
+  map.set(tainted, value);
+  let ret_val_untainted = map.get(untainted)
+  let ret_val_tainted = map.get(tainted)
+  assertEq(ret_val_tainted, ret_val_untainted);
+}
+
+runTaintTest(mapTaintTest);
+
+
+if (typeof reportCompare === 'function')
+  reportCompare(true, true);
+

--- a/js/src/tests/non262/taint/maps.js
+++ b/js/src/tests/non262/taint/maps.js
@@ -1,5 +1,4 @@
-function mapTaintTest() {
-
+function mapTaintedKeyTest() {
   let map = new Map(); 
   let tainted = taint(42);
   let untainted = 42;
@@ -10,7 +9,19 @@ function mapTaintTest() {
   assertEq(ret_val_tainted, ret_val_untainted);
 }
 
+function mapUntaintedKeyTest() {
+  let map = new Map(); 
+  let tainted = taint(42);
+  let untainted = 42;
+  let value = "foo";
+  map.set(untainted, value);
+  let ret_val_untainted = map.get(untainted)
+  let ret_val_tainted = map.get(tainted)
+  assertEq(ret_val_tainted, ret_val_untainted);
+}
+
 runTaintTest(mapTaintTest);
+runTaintTest(mapUntaintedKeyTest);
 
 
 if (typeof reportCompare === 'function')


### PR DESCRIPTION
Currently, the Map object calculates different hash values for the number 42 and the tainted number 42. This leads to issues when storing a mix of tainted and untainted numbers in a Map. This is what makes the Playwright integration fail for this branch (at least one of the reasons).

I have played around with the Map object but did not find a nice way to fix it (yet)? So I'm just pushing the test case to simplify debugging and fixing this issue.