### PR TITLE
Primitaint: Inconsistent behavior in switch-cases

### DIFF
--- a/js/src/tests/non262/taint/switch-case.js
+++ b/js/src/tests/non262/taint/switch-case.js
@@ -1,0 +1,28 @@
+function taintSwitchCaseTest() {
+
+    let tableSwitchOptimized = 1;
+    let tableSwitchOptimizedTainted = Number.tainted(tableSwitchOptimized);
+
+    switch (tableSwitchOptimizedTainted) {
+        case tableSwitchOptimized:
+            break;
+        default:
+            throw new Error("Taints should not be propagated in optimized switch cases");
+    }
+
+    let tableSwitchUnoptimized = 123456789;
+    let tableSwitchUnoptimizedTainted = Number.tainted(tableSwitchUnoptimized);
+
+    switch (tableSwitchUnoptimizedTainted) {
+        case tableSwitchUnoptimized:
+            break;
+        default:
+            throw new Error("Taints should not be propagated in optimized switch cases");
+    }
+}
+
+runTaintTest(taintSwitchCaseTest);
+
+if (typeof reportCompare === 'function')
+  reportCompare(true, true);
+

--- a/js/src/vm/Interpreter.cpp
+++ b/js/src/vm/Interpreter.cpp
@@ -3330,6 +3330,9 @@ bool MOZ_NEVER_INLINE JS_HAZ_JSNATIVE_CALLER js::Interpret(JSContext* cx,
       int32_t i;
       if (rref.isInt32()) {
         i = rref.toInt32();
+      }
+      else if (isTaintedNumber(rref)) {
+        i = rref.toObject().as<NumberObject>().unbox();
       } else {
         /* Use mozilla::NumberEqualsInt32 to treat -0 (double) as 0. */
         if (!rref.isDouble() || !NumberEqualsInt32(rref.toDouble(), &i)) {


### PR DESCRIPTION
While switch-cases are typically strictly checked, they are optimized for [small integer constants](https://github.com/SAP/project-foxhound/blob/main/js/src/vm/Opcodes.h#L2471). 

This results in the following inconsistency:

```js
switch (Number.tainted(1234567)) {
  case 1234567:
    console.log("1"); // prints 1
    break;
  default:
    console.log("0");
    break;
}
```

```js
switch (Number.tainted(1)) {
  case 1:
    console.log("1");
    break;
  default:
    console.log("0"); // prints 0
    break;
}
```

My approach to resolving this issue (akin to af544cf) is to check for taints in the [discriminant](https://github.com/0drai/project-foxhound/blob/main/js/src/vm/Interpreter.cpp#L3324) and unbox it if necessary. 