### PR TITLE
Fixes Array.indexOf/includes for tainted numbers

### DIFF
--- a/js/src/tests/non262/taint/arrays.js
+++ b/js/src/tests/non262/taint/arrays.js
@@ -1,0 +1,41 @@
+function indexOfTestTaintedValue() {
+  let tnum = taint(42);
+  let nums_t = [1,tnum,3];
+  let nums_ut = [1,42,3];
+  let idx_t = nums_t.indexOf(42);
+  let idx_ut = nums_ut.indexOf(42);
+  assertEq(idx_ut, idx_t);
+}
+
+function indexOfTestTaintedKey() {
+  let tnum = taint(42);
+  let nums = [1,42,3];
+  let idx_t = nums.indexOf(tnum);
+  let idx_ut = nums.indexOf(42);
+  assertEq(idx_ut, idx_t);
+}
+
+function includesTestTaintedKey() {
+  let tnum = taint(42);
+  let nums = [1,42,3];
+  let inc_t = nums.includes(tnum);
+  let inc_ut = nums.includes(42);
+  assertEq(inc_ut, inc_t);
+}
+
+function includesTestTaintedValue() {
+  let tnum = taint(42);
+  let nums = [1,tnum,3];
+  let inc_t = nums.includes(tnum);
+  let inc_ut = nums.includes(42);
+  assertEq(inc_ut, inc_t);
+}
+
+runTaintTest(indexOfTestTaintedValue);
+runTaintTest(indexOfTestTaintedKey);
+runTaintTest(includesTestTaintedKey);
+runTaintTest(includesTestTaintedValue);
+
+
+if (typeof reportCompare === 'function')
+  reportCompare(true, true);

--- a/js/src/vm/EqualityOperations.h
+++ b/js/src/vm/EqualityOperations.h
@@ -18,6 +18,7 @@
 #ifndef vm_EqualityOperations_h
 #define vm_EqualityOperations_h
 
+#include "jstaint.h"        // JS::isTaintedNUmber
 #include "jstypes.h"        // JS_PUBLIC_API
 #include "js/RootingAPI.h"  // JS::Handle
 #include "js/Value.h"       // JS::Value
@@ -64,7 +65,7 @@ extern bool SameValueZero(JSContext* cx, JS::Handle<JS::Value> v1,
  * integers too.
  */
 inline bool CanUseBitwiseCompareForStrictlyEqual(const JS::Value& v) {
-  return v.isObject() || v.isSymbol() || v.isNullOrUndefined() || v.isBoolean();
+  return (v.isObject() || v.isSymbol() || v.isNullOrUndefined() || v.isBoolean()) && (!JS::isTaintedNumber(v));
 }
 
 }  // namespace js


### PR DESCRIPTION
Before, Array.indexOf and Array.includes had subtle differences in behavior regarding tainted values or keys when using said functions.

This adds a special case for tainted numbers and unboxes them so that they behave the same. It requires flagging tainted numbers as not bitwise comparable, which might have downstream effects (?).

For a demonstration, see the following code:

```javascript
let tkey = taint(42);
let key = 42;
function taintedKeyTest() {
	let nums = [1, key, 3];
	let idx_t = nums.indexOf(tkey);
	let idx_ut = nums.indexOf(key);
	let inc_t = nums.includes(tkey);
	let inc_ut = nums.includes(key);
	console.log(`Index of: t[${idx_t}], ut[${idx_ut}]`);
	console.log(`Includes: t[${inc_t}], ut[${inc_ut}]`);
}

function taintedValueTest() {
	let nums = [1, tkey, 3];
	let idx_t = nums.indexOf(tkey);
	let idx_ut = nums.indexOf(key);
	let inc_t = nums.includes(tkey);
	let inc_ut = nums.includes(key);
	console.log(`Index of: t[${idx_t}], ut[${idx_ut}]`);
	console.log(`Includes: t[${inc_t}], ut[${inc_ut}]`);
}
console.log(`Tainted Key:`);
taintedKeyTest();
console.log(`Tainted value:`);
taintedValueTest();
```

Before, the values did differ for all 4 cases, and now they show the same results.