### PR TITLE
Report taint sink non string

### DIFF
--- a/dom/messagechannel/MessagePort.cpp
+++ b/dom/messagechannel/MessagePort.cpp
@@ -30,6 +30,7 @@
 #include "mozilla/Unused.h"
 #include "nsContentUtils.h"
 #include "nsPresContext.h"
+#include "nsTaintingUtils.h"
 
 #ifdef XP_WIN
 #  undef PostMessage
@@ -284,6 +285,7 @@ JSObject* MessagePort::WrapObject(JSContext* aCx,
 void MessagePort::PostMessage(JSContext* aCx, JS::Handle<JS::Value> aMessage,
                               const Sequence<JSObject*>& aTransferable,
                               ErrorResult& aRv) {
+  ReportTaintSink(aCx, aMessage, "MessagePort.PostMessage");
   // We *must* clone the data here, or the JS::Value could be modified
   // by script
 

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -4934,11 +4934,9 @@ JS_PUBLIC_API void
 JS_ReportTaintSink(JSContext* cx, JS::HandleValue value, const char* sink, JS::HandleValue arg)
 {
   if (value.isString()) {
-    std::cout << "It is a string" << std::endl;
     JSString *str = value.toString();
     if (str) {
       JS::RootedString strobj(cx, str);
-      str->dump();
       JS_ReportTaintSink(cx, strobj, sink, arg);
     }
   }
@@ -5035,12 +5033,10 @@ JS_ReportTaintSink(JSContext* cx, JS::HandleValue value, const char* sink, JS::H
     }
   }
   else if(value.isObject()){
-    std::cout << "THIS IS AN OBJECT" << std::endl;
     JS::Rooted<JS::IdVector> props(cx, JS::IdVector(cx));
     JS::RootedObject rootedObj(cx, &value.toObject());
     JS_Enumerate(cx, rootedObj, &props);
     for (size_t i = 0; i < props.length(); i++) {
-      std::cout << "THIS IS PROPS LOOP" << std::endl;
       JS::RootedId id(cx, props[i]);
       JS::RootedValue val(cx);
       JS_GetPropertyById(cx, rootedObj, id, &val);

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -4934,11 +4934,27 @@ JS_PUBLIC_API void
 JS_ReportTaintSink(JSContext* cx, JS::HandleValue value, const char* sink, JS::HandleValue arg)
 {
   if (value.isString()) {
+    std::cout << "It is a string" << std::endl;
     JSString *str = value.toString();
     if (str) {
       JS::RootedString strobj(cx, str);
+      str->dump();
       JS_ReportTaintSink(cx, strobj, sink, arg);
     }
+  }
+
+  if(value.isObject()){
+    JS::RootedString jsonString(cx, JS::ToString(cx, value));
+    // char* utf8Chars = JS_EncodeStringToUTF8(cx, jsonString);
+    // std::cout << "It is an object" << std::endl;
+    // NativeObject *obj = MaybeNativeObject(value.toObjectOrNull());
+    // if (obj) {
+    //   for (size_t i = 0; i < obj->slotSpan(); i++) {
+    //     JS::Value slot = obj->getSlot(i);
+    //     std::cout << slot.asRawBits() << std::endl;
+    //     JS_ReportTaintSink(cx, RootedValue(cx, slot), sink, arg);
+    //   }
+    // }
   }
 }
 

--- a/js/src/jsapi.cpp
+++ b/js/src/jsapi.cpp
@@ -4942,20 +4942,130 @@ JS_ReportTaintSink(JSContext* cx, JS::HandleValue value, const char* sink, JS::H
       JS_ReportTaintSink(cx, strobj, sink, arg);
     }
   }
-
   if(value.isObject()){
-    JS::RootedString jsonString(cx, JS::ToString(cx, value));
-    // char* utf8Chars = JS_EncodeStringToUTF8(cx, jsonString);
-    // std::cout << "It is an object" << std::endl;
-    // NativeObject *obj = MaybeNativeObject(value.toObjectOrNull());
-    // if (obj) {
-    //   for (size_t i = 0; i < obj->slotSpan(); i++) {
-    //     JS::Value slot = obj->getSlot(i);
-    //     std::cout << slot.asRawBits() << std::endl;
-    //     JS_ReportTaintSink(cx, RootedValue(cx, slot), sink, arg);
-    //   }
-    // }
+    std::cout << "THIS IS AN OBJECT" << std::endl;
+    JS::Rooted<JS::IdVector> props(cx, JS::IdVector(cx));
+      JS_Enumerate(cx, RootedObject(cx, &value.toObject()), &props);
+      for (size_t i = 0; i < props.length(); i++) {
+        std::cout << "THIS IS PROPS LOOP" << std::endl;
+        JS::RootedId id(cx, props[i]);
+        JS::RootedValue keyVal(cx);
+        JS_IdToValue(cx, id, &keyVal);
+        if(keyVal.isString()){
+          keyVal.toString()->dump();
+        }
+        if(keyVal.isNumber()){
+          std::cout << "KEYVAL IS A NUMBER: " << keyVal.toNumber() << std::endl;
+          if(isTaintedNumber(keyVal)){
+            std::cout << "KEYVAL IS TAINTED NUMBER: " << keyVal.toNumber() << std::endl;
+            // JS_ReportTaintSink(cx, RootedValue(cx, keyVal), sink, arg);
+          }
+        }
+
+        JS_ReportTaintSink(cx, keyVal, sink, arg);
+      }
+    NativeObject *obj = MaybeNativeObject(value.toObjectOrNull());
+    if (obj) {
+      for (size_t i = 0; i < obj->slotSpan(); i++) {
+        std::cout << "THIS IS SLOT LOOP" << std::endl;
+        JS::Value slot = obj->getSlot(i);
+        JS_ReportTaintSink(cx, RootedValue(cx, slot), sink, arg);
+      }
+    }
   }
+
+  if(isTaintedNumber(value)){
+    std::cout << "It is a tainted number!!" << std::endl;
+    NumberObject& number = value.toObject().as<NumberObject>();
+    // JS_ReportTaintSink(cx, &number, sink, arg);
+      const unsigned TAINT_REPORT_FUNCTION_SLOT = 5;
+
+      MOZ_ASSERT(!cx->isExceptionPending());
+
+      // Print a message to stdout. Also include the current JS backtrace.
+      auto flow = number.taint();
+
+      std::cerr << "!!! Tainted flow into " << sink << " from " << flow.source().name() << " !!!" << std::endl;
+      // DumpBacktrace(cx);
+
+      // Report a warning to show up on the web console
+      JS_ReportWarningUTF8(cx, "Tainted flow from %s into %s!", flow.source().name(), sink);
+
+      // Extend the taint flow to include the sink function
+      number.taint().extend(TaintOperationFromContext(cx, sink, true, arg, true));
+
+      // Trigger a custom event that can be caught by an extension.
+      // To simplify things, this part is implemented in JavaScript. Since we don't want to recompile
+      // this code everytime we detect a tainted flow, we store the compiled function into a reserved
+      // slot of the current global object.
+      RootedFunction report(cx);
+
+      JSObject* global = cx->global();
+
+      RootedValue slot(cx, JS::GetReservedSlot(global, TAINT_REPORT_FUNCTION_SLOT));
+      if (slot.isUndefined()) {
+        // Need to compile.
+        const char* argnames[3] = {"str", "sink", "stack"};
+        const char* funbody =
+          "if (typeof window !== 'undefined' && typeof document !== 'undefined') {\n"
+          "    var t = window;\n"
+          "    if (location.protocol == 'javascript:' || location.protocol == 'data:' || location.protocol == 'about:') {\n"
+          "        t = parent.window;\n"
+          "    }\n"
+          "    var pl;\n"
+          "    try {\n"
+          "        pl = parent.location.href;\n"
+          "    } catch (e) {\n"
+          "        pl = 'different origin';\n"
+          "    }\n"
+          "    var e = document.createEvent('CustomEvent');\n"
+          "    e.initCustomEvent('__taintreport', true, false, {\n"
+          "        subframe: t !== window,\n"
+          "        loc: location.href,\n"
+          "        parentloc: pl,\n"
+          "        referrer: document.referrer,\n"
+          "        str: str,\n"
+          "        sink: sink,\n"
+          "        stack: stack\n"
+          "    });\n"
+          "    t.dispatchEvent(e);\n"
+          "}";
+        CompileOptions options(cx);
+        options.setFile("taint_reporting.js");
+
+        RootedObjectVector emptyScopeChain(cx);
+        report = CompileFunctionUtf8(cx, emptyScopeChain,
+                                     options, "ReportTaintSink", 3,
+                                     argnames, funbody, strlen(funbody));
+        MOZ_ASSERT(report);
+
+        // Store the compiled function into the current global object.
+        JS_SetReservedSlot(global, TAINT_REPORT_FUNCTION_SLOT, ObjectValue(*report));
+      } else {
+        report = JS_ValueToFunction(cx, slot);
+      }
+
+      RootedObject stack(cx);
+      if (!JS::CaptureCurrentStack(cx, &stack,
+                                   JS::StackCapture(JS::AllFrames()))) {
+        JS_ReportErrorUTF8(cx, "Invalid stack object in CaptureCurrentStack!");
+        return;
+      }
+
+      JS::RootedValueArray<3> arguments(cx);
+      arguments[0].setNumber(5);
+      arguments[1].setString(NewStringCopyZ<CanGC>(cx, sink));
+      if (stack) {
+        arguments[2].setObject(*stack);
+      } else {
+        arguments[2].setUndefined();
+      }
+
+      RootedValue rval(cx);
+      JS_CallFunction(cx, nullptr, report, arguments, &rval);
+      MOZ_ASSERT(!cx->isExceptionPending());
+  }
+
 }
 
 JS_PUBLIC_API void


### PR DESCRIPTION
Added the ability to report taint sinks that are not strings. In most cases, even if an object is sent to a sink, it is implicitly transformed into a string before going to the sink. However, there are some cases like messageport sink that send the JSValue itself without implicitly transforming it to a NSString. This PR deals with these cases.