### PR TITLE
Fixed taint propagation for String conversion fast path and utf8 strings

### DIFF
--- a/dom/base/nsJSUtils.h
+++ b/dom/base/nsJSUtils.h
@@ -119,12 +119,14 @@ inline bool AssignJSString(JSContext* cx, T& dest, JSString* s) {
     if (chars[len] == '\0') {
       AssignFromStringBuffer(
           nsStringBuffer::FromData(const_cast<char16_t*>(chars)), len, dest);
+      dest.AssignTaint(JS_GetStringTaint(s));
       return true;
     }
   } else if (XPCStringConvert::MaybeGetLiteralStringChars(s, &chars)) {
     // The characters represent a literal char16_t string constant
     // compiled into libxul; we can just use it as-is.
     dest.AssignLiteral(chars, len);
+    dest.AssignTaint(JS_GetStringTaint(s));
     return true;
   }
 
@@ -184,6 +186,7 @@ inline bool AssignJSString(JSContext* cx, T& dest, JSString* s) {
 
   MOZ_ASSERT(read == JS::GetStringLength(s));
   handle.Finish(written, kAllowShrinking);
+  dest.AssignTaint(JS_GetStringTaint(s));
   return true;
 }
 

--- a/dom/bindings/BindingUtils.h
+++ b/dom/bindings/BindingUtils.h
@@ -2589,6 +2589,7 @@ inline bool NonVoidUTF8StringToJsval(JSContext* cx, const nsACString& str,
   if (!jsStr) {
     return false;
   }
+  JS_SetStringTaint(cx, jsStr, str.Taint());
   rval.setString(jsStr);
   return true;
 }


### PR DESCRIPTION
The taint was being lost for string conversion due to fast path being taken when classes were being used.  The taint was also being lost for utf8 conversion (special case). Both issues have been fixed and tested.