### PR TITLE
URL Search Parameters toString() Taint Propagation

### DIFF
--- a/dom/url/URLSearchParams.cpp
+++ b/dom/url/URLSearchParams.cpp
@@ -157,7 +157,9 @@ void URLSearchParams::Serialize(nsACString& aValue) const {
 void URLSearchParams::Stringify(nsAString& aValue) const {
   nsAutoCString serialized;
   mParams->Serialize(serialized, true);
+  SafeStringTaint taint = serialized.Taint();
   CopyUTF8toUTF16(serialized, aValue);
+  aValue.AssignTaint(taint);
 }
 
 void URLSearchParams::NotifyObserver() {


### PR DESCRIPTION
Due to the following commit: [here](https://github.com/SAP/project-foxhound/commit/e4ddf241478326ad6f4d3dcaaece7aedeb4bc880#diff-48dc74f57701467d4c42dcddcf98165bc03bd8a8a2f1677aad83845328821266) the toString() operation on URLSearchParams did drop all taints.

This restores this by propagating it over the lossy UTF conversion function.